### PR TITLE
Fix for public machine image search.

### DIFF
--- a/src/main/java/org/dasein/cloud/vcloud/compute/TemplateSupport.java
+++ b/src/main/java/org/dasein/cloud/vcloud/compute/TemplateSupport.java
@@ -784,7 +784,7 @@ public class TemplateSupport implements MachineImageSupport {
                         ok = true;
                     }
                 }
-                if( ok ) {
+                if( !ok ) {
                     return Collections.emptyList();
                 }
             }
@@ -1170,7 +1170,7 @@ public class TemplateSupport implements MachineImageSupport {
             matches.add(img);
         }
         for( MachineImage img : searchPublicImages(keyword, platform, architecture, ImageClass.MACHINE) ) {
-            if( matches.contains(img) ) {
+            if( !matches.contains(img) ) {
                 matches.add(img);
             }
         }


### PR DESCRIPTION
There were some minor logic issues in searchMachineImage and searchPublicImages methods. 

Tested in dev.

In 2013.04 the  method searchMachineImage does not exist and the searchPublicImages method is different, so I only created a pull request for 2013.02.

Binod
